### PR TITLE
Fixed error on calculator

### DIFF
--- a/src/components/molecules/CurrencyExchangeForm.tsx
+++ b/src/components/molecules/CurrencyExchangeForm.tsx
@@ -27,9 +27,9 @@ const CurrencyExchangeForm: React.FC<CurrencyExchangeFormProps> = ({
       setTotal('Invalid rate')
       return
     }
-    const rate = exchangeRates.find(rate => rate.code === currency)?.rate
+    const rate = exchangeRates.find(rate => rate.code === currency)
     if (rate) {
-      const convertedAmount = (Number(amount) / rate).toFixed(2)
+      const convertedAmount = ((Number(amount)*(rate.ratePer100CZK/100))).toFixed(2)
       setTotal(`${convertedAmount} ${currency}`)
     } else {
       setTotal('Invalid rate')


### PR DESCRIPTION
# Description
Fixed an error on the calculator when using units whose `amount` was greater than 1, such as Thai Baht.

# How to know this works?
I checked it manually, here are some screenshots:

<img width="432" alt="Screenshot 2025-01-22 at 17 57 58" src="https://github.com/user-attachments/assets/7c62d861-1087-49f9-a1bd-f880c8c3e2d3" />
<img width="443" alt="Screenshot 2025-01-22 at 17 58 34" src="https://github.com/user-attachments/assets/5f632823-7c93-4557-97ad-248745d4d34c" />

### Comparison against google exchange

<img width="283" alt="Screenshot 2025-01-22 at 18 03 28" src="https://github.com/user-attachments/assets/2bd2a33b-90f0-43ff-95e9-3a5e7a569705" />

<img width="218" alt="Screenshot 2025-01-22 at 18 04 24" src="https://github.com/user-attachments/assets/1733a983-27e1-47e1-901c-c434b14e0a05" />

